### PR TITLE
add File.mkdir_p("tmp")

### DIFF
--- a/lib/jnnnx/mnist/dataset.ex
+++ b/lib/jnnnx/mnist/dataset.ex
@@ -26,6 +26,7 @@ defmodule Jnnnx.MNIST.Dataset do
   end
 
   defp load_data_for(file_name) do
+    File.mkdir_p("tmp")
     tmp_file = Path.absname(file_name, "tmp")
 
     if File.exists?(tmp_file) do


### PR DESCRIPTION
Hi, it's nice to meet you.

`tmp`がもともとあっても動くように、[File.mkdir_p/1](https://hexdocs.pm/elixir/File.html#mkdir_p/1)のほうでつくるようにしてみました。