### PR TITLE
add example code as exs file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ score = Jnnnx.evaluate(params, x_test, y_test)
 IO.puts("Accuracy: #{Nx.to_scalar(score)}")
 ```
 
+The above code is copied to `example/keras_like_manner.exs`.  
+You can also try it as the follow.
+
+```shell
+$ mix run example/keras_like_manner.exs
+```
+
 ## Author
 
 Kentaro Kuribayashi &lt;kentarok@gmail.com&gt;

--- a/example/keras_like_manner.exs
+++ b/example/keras_like_manner.exs
@@ -1,0 +1,23 @@
+# loading data
+[x_train, y_train, x_test, y_test] = Jnnnx.MNIST.Dataset.load_data()
+
+# normalization
+x_train =
+  x_train
+  |> Nx.reshape({60000, 28*28}, names: [:batch, :input])
+  |> Nx.divide(255)
+x_test =
+  x_test
+  |> Nx.reshape({10000, 28*28}, names: [:batch, :input])
+  |> Nx.divide(255)
+
+# one-hot-encoding
+y_train = y_train |> Jnnnx.Utils.to_categorical(10, names: [:batch, :output])
+y_test  = y_test  |> Jnnnx.Utils.to_categorical(10, names: [:batch, :output])
+
+# training
+params = Jnnnx.fit(x_train, y_train, epoch: 5, batch_size: 50, learning_rate: 0.01)
+
+# evaluation
+score = Jnnnx.evaluate(params, x_test, y_test)
+IO.puts("Accuracy: #{Nx.to_scalar(score)}")


### PR DESCRIPTION
READMEのサンプルコードをワンライナーで実行できるようにしてみました．

ちなみに[当方でのベンチマークの結果](https://twitter.com/takasehideki/status/1365239058247479297)です
Xeon W-2155 10-core 3.30 GHz / 64 GB Memory

```shell
$ time mix run example/keras_like_manner.exs
epoch 1, batch 0
epoch 1, batch 1
~~
epoch 5, batch 1198
epoch 5, batch 1199
Accuracy: 0.9208

real    439m28.307s
user    652m6.966s
sys     73m10.682s
```